### PR TITLE
Fix requirements.txt

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,13 +1,6 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2822
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
-
-\f0\fs24 \cf0 pyinstaller\
-pillow\
-img2pdf\
-pypdf\
-pdf2image\
-psutil}
+pyinstaller
+pillow
+img2pdf
+pypdf
+pdf2image
+psutil


### PR DESCRIPTION
The pip installer failed to install the dependencies due to this file isn't in plain text (it was saved as an RTF file according to Gemini).

I removed the color and formatting information and turned it into just plain text for the pip installer to be happy about it.

Theoretically fixes issue: #10 